### PR TITLE
Use synchronous API unless required otherwise

### DIFF
--- a/backends/apple/mps/runtime/MPSStream.h
+++ b/backends/apple/mps/runtime/MPSStream.h
@@ -37,6 +37,7 @@ class MPSStream {
     return _serialQueue;
   }
 
+  bool hasLiveCommandBuffer();
   MPSCommandBuffer* commandBuffer();
   id<MTLComputeCommandEncoder> commandEncoder();
   void endKernelCoalescing();

--- a/backends/apple/mps/runtime/MPSStream.mm
+++ b/backends/apple/mps/runtime/MPSStream.mm
@@ -53,6 +53,10 @@ MPSStream::~MPSStream() {
   assert(_commandBuffer == nil);
 }
 
+bool MPSStream::hasLiveCommandBuffer() {
+  return _commandBuffer;
+}
+
 MPSCommandBuffer* MPSStream::commandBuffer() {
   if (!_commandBuffer) {
     _commandBuffer = [MPSCommandBuffer commandBufferFromCommandQueue:_commandQueue].retain;


### PR DESCRIPTION
Let MPSGraph handle the command buffer if there isn't one which exists at the moment.